### PR TITLE
fix for starting services with a "run" method

### DIFF
--- a/bootstrap-node.js
+++ b/bootstrap-node.js
@@ -103,7 +103,7 @@ function loadAndStart(paramsToScript, appId) {
 		//console.log('loading node module from ' + service_dir);
 		var mod = require(service_dir);
 		if (mod.run) {
-			mod.run(name);
+			mod.run(appId);
 		}
 	} else if (fs.existsSync('sources.json')) { // mojoservice-based service
 		loadSource();


### PR DESCRIPTION
Previously having a "run" method in a service that is not run via the
unified server would generate a runtime error that "name" does not exist.

This fixes it, so you can use services that are intended to start via
"run()", for nice things like setting up dependency injection